### PR TITLE
Moving where the privileges tooltips are specified

### DIFF
--- a/x-pack/plugins/ml/index.js
+++ b/x-pack/plugins/ml/index.js
@@ -79,11 +79,6 @@ export const ml = (kibana) => {
         navLinkId: 'ml',
         privileges: {
           all: {
-            metadata: {
-              tooltip: i18n.translate('xpack.ml.privileges.tooltip', {
-                defaultMessage: 'The machine_learning_user or machine_learning_admin role should also be assigned to users grant access'
-              })
-            },
             catalogue: ['ml'],
             app: ['ml', 'kibana'],
             savedObject: {
@@ -92,7 +87,10 @@ export const ml = (kibana) => {
             },
             ui: [],
           },
-        }
+        },
+        privilegesTooltip: i18n.translate('xpack.ml.privileges.tooltip', {
+          defaultMessage: 'The machine_learning_user or machine_learning_admin role should also be assigned to users grant access'
+        })
       });
 
       // Add server routes and initialize the plugin here

--- a/x-pack/plugins/monitoring/init.js
+++ b/x-pack/plugins/monitoring/init.js
@@ -64,11 +64,6 @@ export const init = (monitoringPlugin, server) => {
     navLinkId: 'monitoring',
     privileges: {
       all: {
-        metadata: {
-          tooltip: i18n.translate('xpack.monitoring.privileges.tooltip', {
-            defaultMessage: 'The monitoring_user role should also be assigned to users to grant access'
-          })
-        },
         catalogue: ['monitoring'],
         app: ['monitoring', 'kibana'],
         savedObject: {
@@ -77,7 +72,10 @@ export const init = (monitoringPlugin, server) => {
         },
         ui: [],
       },
-    }
+    },
+    privilegesTooltip: i18n.translate('xpack.monitoring.privileges.tooltip', {
+      defaultMessage: 'The monitoring_user role should also be assigned to users to grant access'
+    })
   });
 
   const bulkUploader = initBulkUploader(kbnServer, server);

--- a/x-pack/plugins/security/public/views/management/edit_role/components/privileges/kibana/feature_table/feature_table.tsx
+++ b/x-pack/plugins/security/public/views/management/edit_role/components/privileges/kibana/feature_table/feature_table.tsx
@@ -40,11 +40,6 @@ interface Props {
   disabled?: boolean;
 }
 
-interface ToolTipDefinition {
-  privilegeId: string;
-  tooltip: string;
-}
-
 interface TableFeature extends Feature {
   hasAnyPrivilegeAssigned: boolean;
 }
@@ -105,30 +100,11 @@ export class FeatureTable extends Component<Props, {}> {
         defaultMessage: 'Feature',
       }),
       render: (feature: TableFeature) => {
-        const tooltips = Object.entries(feature.privileges).reduce(
-          (acc: ToolTipDefinition[], [privilegeId, privilege]) => {
-            if (!privilege.metadata || !privilege.metadata.tooltip) {
-              return acc;
-            }
-
-            return [
-              ...acc,
-              {
-                privilegeId,
-                tooltip: privilege.metadata.tooltip,
-              },
-            ];
-          },
-          [] as ToolTipDefinition[]
-        );
-
         let tooltipElement = null;
-        if (tooltips.length > 0) {
+        if (feature.privilegesTooltip) {
           const tooltipContent = (
             <EuiText>
-              {tooltips.map(tip => (
-                <p key={tip.privilegeId}>{tip.tooltip}</p>
-              ))}
+              <p>{feature.privilegesTooltip}</p>
             </EuiText>
           );
           tooltipElement = (

--- a/x-pack/plugins/xpack_main/server/lib/feature_registry/feature_registry.test.ts
+++ b/x-pack/plugins/xpack_main/server/lib/feature_registry/feature_registry.test.ts
@@ -39,9 +39,6 @@ describe('registerFeature', () => {
       validLicenses: ['standard', 'basic', 'gold', 'platinum'],
       privileges: {
         all: {
-          metadata: {
-            tooltip: 'some fancy tooltip',
-          },
           app: ['app1', 'app2'],
           savedObject: {
             all: ['config', 'space', 'etc'],
@@ -51,6 +48,7 @@ describe('registerFeature', () => {
           ui: ['allowsFoo', 'showBar', 'showBaz'],
         },
       },
+      privilegesTooltip: 'some fancy tooltip',
     };
 
     registerFeature(feature);
@@ -100,9 +98,6 @@ describe('registerFeature', () => {
       name: 'Test Feature',
       privileges: {
         ['some invalid key']: {
-          metadata: {
-            tooltip: 'some fancy tooltip',
-          },
           app: ['app1', 'app2'],
           savedObject: {
             all: ['config', 'space', 'etc'],

--- a/x-pack/plugins/xpack_main/server/lib/feature_registry/feature_registry.ts
+++ b/x-pack/plugins/xpack_main/server/lib/feature_registry/feature_registry.ts
@@ -10,9 +10,6 @@ import _ from 'lodash';
 import { UICapabilities } from 'ui/capabilities';
 
 export interface FeaturePrivilegeDefinition {
-  metadata?: {
-    tooltip?: string;
-  };
   management?: {
     [sectionId: string]: string[];
   };
@@ -36,6 +33,7 @@ export interface Feature {
   privileges: {
     [key: string]: FeaturePrivilegeDefinition;
   };
+  privilegesTooltip?: string;
 }
 
 // Each feature gets its own property on the UICapabilities object,
@@ -60,9 +58,6 @@ const schema = Joi.object({
     .pattern(
       featurePrivilegePartRegex,
       Joi.object({
-        metadata: Joi.object({
-          tooltip: Joi.string(),
-        }),
         management: Joi.object().pattern(managementSectionIdRegex, Joi.array().items(Joi.string())),
         catalogue: Joi.array().items(Joi.string()),
         api: Joi.array().items(Joi.string()),
@@ -83,6 +78,7 @@ const schema = Joi.object({
       })
     )
     .required(),
+  privilegesTooltip: Joi.string(),
 });
 
 const features: Record<string, Feature> = {};


### PR DESCRIPTION
I played around with being able to specify the tooltip/metadata as the direct descendant of the `privileges` key for the Feature, but it got complicated from a type perspective. We end up wanting a Record/Dictionary for all other strings except for `metadata`/`tooltip`, which TypeScript doesn't have first-class support for. 

I also considered changing the `privileges` type for Feature to have two children, so it'd be something like:

```
...
items: {
  [string: key]: FeaturePrivilegeDefinition;
},
metadata?: {
  tooltip?: string;
}
...
```

but that seemed quite inconvenient and breaking in tradition from the other feature properties, so I gave up and did what we have here... 

I'm open to other suggestions, I'm not partial towards any at this point.