### PR TITLE
Quick width fixes

### DIFF
--- a/x-pack/plugins/spaces/public/views/management/_index.scss
+++ b/x-pack/plugins/spaces/public/views/management/_index.scss
@@ -1,2 +1,1 @@
-@import './manage_spaces';
 @import './components/confirm_delete_modal';

--- a/x-pack/plugins/spaces/public/views/management/_manage_spaces.scss
+++ b/x-pack/plugins/spaces/public/views/management/_manage_spaces.scss
@@ -1,6 +1,0 @@
-.spcManagePage {
-  max-width: 640px;
-  margin-left: auto;
-  margin-right: auto;
-  flex-grow: 0;
-}

--- a/x-pack/plugins/spaces/public/views/management/components/secure_space_message/secure_space_message.tsx
+++ b/x-pack/plugins/spaces/public/views/management/components/secure_space_message/secure_space_message.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License.
  */
 
-import { EuiLink, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiHorizontalRule, EuiLink, EuiText } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import React, { Fragment } from 'react';
 import { uiCapabilities } from 'ui/capabilities';
@@ -13,7 +13,7 @@ export const SecureSpaceMessage = ({}) => {
   if (uiCapabilities.spaces.manage) {
     return (
       <Fragment>
-        <EuiSpacer />
+        <EuiHorizontalRule />
         <EuiText className="eui-textCenter">
           <p>
             <FormattedMessage

--- a/x-pack/plugins/spaces/public/views/management/edit_space/customize_space/customize_space.tsx
+++ b/x-pack/plugins/spaces/public/views/management/edit_space/customize_space/customize_space.tsx
@@ -14,7 +14,6 @@ import {
   EuiPopover,
   EuiPopoverProps,
   EuiSpacer,
-  EuiText,
   EuiTextArea,
   EuiTitle,
 } from '@elastic/eui';
@@ -186,24 +185,20 @@ export class CustomizeSpace extends Component<Props, State> {
   };
 
   public getPanelDescription = () => {
-    return (
-      <EuiText>
-        {this.props.editingExistingSpace ? (
-          <p>
-            <FormattedMessage
-              id="xpack.spaces.management.manageSpacePage.customizeSpacePanelUrlIdentifierNotEditable"
-              defaultMessage="The url identifier cannot be changed."
-            />
-          </p>
-        ) : (
-          <p>
-            <FormattedMessage
-              id="xpack.spaces.management.manageSpacePage.customizeSpacePanelUrlIdentifierEditable"
-              defaultMessage="Note the URL identifier. You cannot change it after you create the space."
-            />
-          </p>
-        )}
-      </EuiText>
+    return this.props.editingExistingSpace ? (
+      <p>
+        <FormattedMessage
+          id="xpack.spaces.management.manageSpacePage.customizeSpacePanelUrlIdentifierNotEditable"
+          defaultMessage="The url identifier cannot be changed."
+        />
+      </p>
+    ) : (
+      <p>
+        <FormattedMessage
+          id="xpack.spaces.management.manageSpacePage.customizeSpacePanelUrlIdentifierEditable"
+          defaultMessage="Note the URL identifier. You cannot change it after you create the space."
+        />
+      </p>
     );
   };
 

--- a/x-pack/plugins/spaces/public/views/management/edit_space/manage_space_page.tsx
+++ b/x-pack/plugins/spaces/public/views/management/edit_space/manage_space_page.tsx
@@ -9,7 +9,6 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
-  EuiPageContent,
   EuiPageContentBody,
   EuiSpacer,
   EuiText,
@@ -114,10 +113,10 @@ class ManageSpacePageUI extends Component<Props, State> {
     const content = this.state.isLoading ? this.getLoadingIndicator() : this.getForm();
 
     return (
-      <div className="spcManagePage">
+      <Fragment>
         <EuiPageContentBody>{content}</EuiPageContentBody>
         {this.maybeGetSecureSpacesMessage()}
-      </div>
+      </Fragment>
     );
   }
 


### PR DESCRIPTION
So I noticed that the spaces pages are all contained under `.mgtPage__body` which is taking care of the max-width. 

You layout with the left and right columns look fine with the extended width, it was the original layout that I was looking at.

This is just a few tiny fixes.