### PR TITLE
Copy to spaces design tweaks

### DIFF
--- a/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/_index.scss
+++ b/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/_index.scss
@@ -1,15 +1,23 @@
 
 .spcCopyToSpaceResult {
   padding-bottom: $euiSizeS;
-  border-bottom: 1px solid $euiColorLightShade;
+  border-bottom: $euiBorderThin;
 }
 
 .spcCopyToSpaceResultDetails {
-  background-color: $euiColorLightestShade;
-  padding-left: $euiSize;
+  margin-top: $euiSizeS;
+  padding-left: $euiSizeL;
+}
+
+.spcCopyToSpaceResultDetails__row {
+  margin-bottom: $euiSizeXS;
 }
 
 .spcCopyToSpaceResultDetails__savedObjectName {
   // Constrains name to the flex item, and allows for truncation when necessary
   min-width: 0;
+}
+
+.spcCopyToSpace__spacesList {
+  margin-top: $euiSizeXS;
 }

--- a/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/copy_result_details.tsx
+++ b/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/copy_result_details.tsx
@@ -59,9 +59,15 @@ export const CopyResultDetails = (props: Props) => {
           !showOverwriteButton && objectOverwritePending && !props.conflictResolutionInProgress;
 
         return (
-          <EuiFlexGroup responsive={false} key={index} alignItems="center" gutterSize="s">
+          <EuiFlexGroup
+            responsive={false}
+            key={index}
+            alignItems="center"
+            gutterSize="s"
+            className="spcCopyToSpaceResultDetails__row"
+          >
             <EuiFlexItem grow={5} className="spcCopyToSpaceResultDetails__savedObjectName">
-              <EuiText>
+              <EuiText size="s">
                 <p className="eui-textTruncate" title={object.name || object.id}>
                   {object.type}: {object.name || object.id}
                 </p>
@@ -69,7 +75,7 @@ export const CopyResultDetails = (props: Props) => {
             </EuiFlexItem>
             {showOverwriteButton && (
               <EuiFlexItem grow={1}>
-                <EuiText>
+                <EuiText size="s">
                   <EuiButtonEmpty onClick={() => onOverwriteClick(object)} size="xs">
                     <FormattedMessage
                       id="xpack.spaces.management.copyToSpace.copyDetail.overwriteButton"
@@ -81,7 +87,7 @@ export const CopyResultDetails = (props: Props) => {
             )}
             {showSkipButton && (
               <EuiFlexItem grow={1}>
-                <EuiText>
+                <EuiText size="s">
                   <EuiButtonEmpty onClick={() => onOverwriteClick(object)} size="xs">
                     <FormattedMessage
                       id="xpack.spaces.management.copyToSpace.copyDetail.skipOverwriteButton"

--- a/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/copy_to_space_flyout.tsx
+++ b/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/copy_to_space_flyout.tsx
@@ -16,6 +16,9 @@ import {
   EuiFormRow,
   EuiFlyoutFooter,
   EuiLoadingSpinner,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiHorizontalRule,
 } from '@elastic/eui';
 import { mapValues } from 'lodash';
 import { i18n } from '@kbn/i18n';
@@ -169,7 +172,6 @@ export const CopyToSpaceFlyout = ({ onClose, savedObject }: Props) => {
 
   const form = (
     <Fragment>
-      <EuiSpacer />
       <EuiSwitch
         label={
           <FormattedMessage
@@ -196,7 +198,7 @@ export const CopyToSpaceFlyout = ({ onClose, savedObject }: Props) => {
         disabled={copyInProgress}
       />
 
-      <EuiSpacer />
+      <EuiHorizontalRule margin="m" />
 
       {/* TODO: remove once https://github.com/elastic/eui/issues/2071 is fixed */}
       {isLoading && <EuiLoadingSpinner />}
@@ -209,6 +211,7 @@ export const CopyToSpaceFlyout = ({ onClose, savedObject }: Props) => {
               defaultMessage="Select spaces to copy into"
             />
           }
+          fullWidth
         >
           <SelectableSpacesControl
             spaces={spaces}
@@ -224,22 +227,34 @@ export const CopyToSpaceFlyout = ({ onClose, savedObject }: Props) => {
   return (
     <EuiFlyout onClose={onClose} maxWidth={600}>
       <EuiFlyoutHeader hasBorder>
-        <EuiTitle size="m">
-          <h2>
+        <EuiFlexGroup alignItems="center" gutterSize="m">
+          <EuiFlexItem grow={false}>
             <EuiIcon size="m" type="spacesApp" />
-            &nbsp; &nbsp;
-            <FormattedMessage
-              id="xpack.spaces.management.copyToSpaceFlyoutHeader"
-              defaultMessage="Copy saved object to space"
-            />
-          </h2>
-        </EuiTitle>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiTitle size="m">
+              <h2>
+                <FormattedMessage
+                  id="xpack.spaces.management.copyToSpaceFlyoutHeader"
+                  defaultMessage="Copy saved object to space"
+                />
+              </h2>
+            </EuiTitle>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
-        <EuiText>
-          <EuiIcon type={savedObject.meta.icon || 'apps'} /> {savedObject.meta.title}
-        </EuiText>
-
+        <EuiFlexGroup alignItems="center" gutterSize="m">
+          <EuiFlexItem grow={false}>
+            <EuiIcon type={savedObject.meta.icon || 'apps'} />
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiText>
+              <p>{savedObject.meta.title}</p>
+            </EuiText>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+        <EuiHorizontalRule margin="m" />
         {copyInProgress && (
           <ProcessingCopyToSpace
             savedObject={savedObject}

--- a/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/copy_to_space_flyout_footer.tsx
+++ b/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/copy_to_space_flyout_footer.tsx
@@ -7,7 +7,14 @@
 import React, { Fragment } from 'react';
 import { ProcessedImportResponse } from 'ui/management/saved_objects_management';
 import { SavedObjectsImportRetry } from 'src/core/server';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiIcon, EuiStat } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiStat,
+  EuiHorizontalRule,
+} from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 
 interface Props {
@@ -109,15 +116,14 @@ export const CopyToSpaceFlyoutFooter = (props: Props) => {
             titleSize="s"
             titleColor={initialCopyFinished ? 'secondary' : 'subdued'}
             isLoading={!initialCopyFinished}
+            textAlign="center"
             description={
               <FormattedMessage
                 id="xpack.spaces.management.copyToSpaceFlyoutFooter.successCount"
-                defaultMessage="copied"
+                defaultMessage="Copied"
               />
             }
-          >
-            <EuiIcon type="empty" />
-          </EuiStat>
+          />
         </EuiFlexItem>
         {summarizedResults.overwriteConflictCount > 0 && (
           <EuiFlexItem>
@@ -126,15 +132,14 @@ export const CopyToSpaceFlyoutFooter = (props: Props) => {
               titleSize="s"
               titleColor={summarizedResults.overwriteConflictCount > 0 ? 'primary' : 'subdued'}
               isLoading={!initialCopyFinished}
+              textAlign="center"
               description={
                 <FormattedMessage
                   id="xpack.spaces.management.copyToSpaceFlyoutFooter.conflictCount"
-                  defaultMessage="pending"
+                  defaultMessage="Pending"
                 />
               }
-            >
-              <EuiIcon type="empty" />
-            </EuiStat>
+            />
           </EuiFlexItem>
         )}
         <EuiFlexItem>
@@ -143,15 +148,14 @@ export const CopyToSpaceFlyoutFooter = (props: Props) => {
             titleSize="s"
             titleColor={summarizedResults.conflictCount > 0 ? 'primary' : 'subdued'}
             isLoading={!initialCopyFinished}
+            textAlign="center"
             description={
               <FormattedMessage
                 id="xpack.spaces.management.copyToSpaceFlyoutFooter.conflictCount"
-                defaultMessage="skipped"
+                defaultMessage="Skipped"
               />
             }
-          >
-            <EuiIcon type="empty" />
-          </EuiStat>
+          />
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiStat
@@ -159,17 +163,17 @@ export const CopyToSpaceFlyoutFooter = (props: Props) => {
             titleSize="s"
             titleColor={summarizedResults.unresolvableErrorCount > 0 ? 'danger' : 'subdued'}
             isLoading={!initialCopyFinished}
+            textAlign="center"
             description={
               <FormattedMessage
                 id="xpack.spaces.management.copyToSpaceFlyoutFooter.errorCount"
-                defaultMessage="errors"
+                defaultMessage="Errors"
               />
             }
-          >
-            <EuiIcon type="empty" />
-          </EuiStat>
+          />
         </EuiFlexItem>
       </EuiFlexGroup>
+      <EuiHorizontalRule />
       {getButton()}
     </Fragment>
   );

--- a/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/processing_copy_to_space.tsx
+++ b/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/processing_copy_to_space.tsx
@@ -16,6 +16,7 @@ import {
   EuiText,
   EuiListGroup,
   EuiListGroupItem,
+  EuiHorizontalRule,
 } from '@elastic/eui';
 import { summarizeCopyResult } from 'plugins/spaces/lib/copy_to_space';
 import { FormattedMessage } from '@kbn/i18n/react';
@@ -46,7 +47,7 @@ export const ProcessingCopyToSpace = (props: Props) => {
 
   return (
     <Fragment>
-      <EuiListGroup className="spcCopyToSpaceOptionsView">
+      <EuiListGroup className="spcCopyToSpaceOptionsView" flush>
         <EuiListGroupItem
           iconType={props.includeRelated ? 'check' : 'cross'}
           label={
@@ -80,7 +81,11 @@ export const ProcessingCopyToSpace = (props: Props) => {
           }
         />
       </EuiListGroup>
-      <EuiSpacer />
+      <EuiHorizontalRule margin="m" />
+      <EuiText size="s">
+        <h5>Copy results</h5>
+      </EuiText>
+      <EuiSpacer size="m" />
       {props.selectedSpaceIds.map(id => {
         const space = props.spaces.find(s => s.id === id) as Space;
         const result = props.copyResult[space.id];

--- a/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/selectable_spaces_control.tsx
+++ b/x-pack/legacy/plugins/spaces/public/views/management/components/copy_to_space/selectable_spaces_control.tsx
@@ -61,7 +61,7 @@ export const SelectableSpacesControl = (props: Props) => {
     <EuiSelectable
       options={options as any[]}
       onChange={newOptions => updateSelectedSpaces(newOptions as SpaceOption[])}
-      listProps={{ bordered: true, rowHeight: 40 }}
+      listProps={{ bordered: true, rowHeight: 40, className: 'spcCopyToSpace__spacesList' }}
       searchable
     >
       {(list, search) => {


### PR DESCRIPTION
Several small touchups to the 'Copy to spaces' UI.

I did bypass an error (3 occurrences) that was not related to things I changed:
`error  Unexpected path "src/core/server/saved_objects/import/types" imported in restricted zone`

